### PR TITLE
Update dependencies for various CVEs.  Also remove explicit dependency on log4j2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### Possible Breaking Dependency Change
 
 - Removed `org.apache.logging.log4j` dependency, instead relying on the org.slf4j logging interface/facade dependency explicitly.
-  - If your project was depending on this transitive dependency you may need to add it to your own project:
+  - If your project was **NOT** depending on this transitive dependency, **no changes are required to upgrade**.
+  - If your project **WAS** depending on this transitive dependency, you may need to add it to your own project:
 
   ```xml
   <dependency>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,38 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.1.1 (UNRELEASED)
+## 3.0.0 (UNRELEASED)
+
+#### Possible Breaking Dependency Change
+
+- Removed `org.apache.logging.log4j` dependency, instead relying on the org.slf4j logging interface/facade dependency explicitly.
+  - If your project was depending on this transitive dependency you may need to add it to your own project:
+
+  ```xml
+  <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.12.1</version>
+  </dependency>
+  <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.12.1</version>
+  </dependency>
+  <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.12.1</version>
+  </dependency>
+  ```
 
 #### Internal Dependency Updates
 - Checkstyle plugin from 8.19 -> 8.24
+- com.fasterxml.jackson.core from 2.9.9 -> 2.10.2
 - org.apache.logging.log4j from 2.11.2 -> 2.12.1
-- org.apache.httpcomponents from 4.5.8 -> 4.5.10
-- com.google.guava:guava from 27.1-jre -> 28.1-jre
-- org.eclipse.jetty:jetty-server (test dependency) from 9.4.17.v20190418 -> 9.4.20.v20190813
+- org.apache.httpcomponents from 4.5.8 -> 4.5.11
+- com.google.guava:guava from 27.1-jre -> 28.2-jre
+- org.eclipse.jetty:jetty-server (test dependency) from 9.4.17.v20190418 -> 9.4.27.v20200227
 - org.mockito:mockito-core (test dependency) from 2.27.0 -> 2.28.2
 
 ## 2.1.0 (06/26/2019)

--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- guava version -->
-        <guava.version>28.1-jre</guava.version>
+        <guava.version>28.2-jre</guava.version>
 
         <!-- Http Components version -->
-        <http-components.version>4.5.10</http-components.version>
+        <http-components.version>4.5.11</http-components.version>
 
         <!-- Jackson version -->
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.10.2</jackson.version>
 
         <!-- Define which version of junit you'll be running -->
         <junit.version>4.12</junit.version>
@@ -65,6 +65,7 @@
 
         <!-- Log4J Version -->
         <log4j2.version>2.12.1</log4j2.version>
+        <slf4j.version>1.7.30</slf4j.version>
 
         <!-- test toggling -->
         <skipTests>false</skipTests>
@@ -103,21 +104,11 @@
             <version>${jackson.version}</version>
         </dependency>
 
-        <!-- Logging -->
+        <!-- Logging Interface -->
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <!-- Testing Tools -->
@@ -165,7 +156,27 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.20.v20190813</version>
+            <version>9.4.27.v20200227</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Logging in tests -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Update various dependencies for CVEs filed against them.  Additionally remove our explicit dependency for log4j2.  Instead explicitly include the slf4 dependency directly, and let end users of the library decide which logging library to use.