### PR TITLE
update dependencies, prep for release of 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.0.1 (08/20/2022)
+#### Internal Dependency Updates
+- com.fasterxml.jackson.core from 2.13.0 -> 2.13.3
+- org.apache.logging.log4j.log4j-api from 2.17.1 -> 2.18.0
+
 ## 4.0.0 (12/10/2021)
 
 **Note:** Major release version updated purely out of abundance of caution.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This client library is released on Maven Central.  Add a new dependency to your 
 <dependency>
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-connect-client</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-connect-client</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <packaging>jar</packaging>
 
     <!-- Require Maven 3.3.9 -->
@@ -50,10 +50,10 @@
         <http-components.version>4.5.13</http-components.version>
 
         <!-- Jackson version -->
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.3</jackson.version>
 
         <!-- Define which version of junit you'll be running -->
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.13.2</junit.version>
 
         <!-- Specify which Checkstyle ruleset to use -->
         <checkstyle.ruleset>build/checkstyle-v1.5.xml</checkstyle.ruleset>
@@ -61,8 +61,8 @@
         <checkstyle.version>8.32</checkstyle.version>
 
         <!-- Log4J Version -->
-        <log4j2.version>2.17.1</log4j2.version>
-        <slf4j.version>1.7.32</slf4j.version>
+        <log4j2.version>2.18.0</log4j2.version>
+        <slf4j.version>1.7.36</slf4j.version>
 
         <!-- test toggling -->
         <skipTests>false</skipTests>
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.43.v20210629</version>
+            <version>9.4.48.v20220622</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
#### Internal Dependency Updates
- com.fasterxml.jackson.core from 2.13.0 -> 2.13.3
- org.apache.logging.log4j.log4j-api from 2.17.1 -> 2.18.0

Additionally some test scoped dependencies were updated.