### PR TITLE
First pass improvements and javadoc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add Constructors to various internal classes: 
   - [ConnectServerVersion](https://github.com/SourceLabOrg/kafka-connect-client/blob/master/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectServerVersion.java#L23)
   - [Task](https://github.com/SourceLabOrg/kafka-connect-client/blob/master/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/Task.java#L25)
-
+- com.fasterxml.jackson.core from 2.13.3 -> 2.13.4
+- 
 ## 4.0.1 (08/20/2022)
 #### Internal Dependency Updates
 - com.fasterxml.jackson.core from 2.13.0 -> 2.13.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.0.2 (10/09/2022)
+## 4.0.2 (10/12/2022)
 - Adds `KafkaConnectClient::restartConnector(final PostConnectorRestart connectorRestartRequest)` [Issue-78](https://github.com/SourceLabOrg/kafka-connect-client/issues/78).
 - Fix Javadoc on KafkaConnectClient::deleteConnector(). [issue-76](https://github.com/SourceLabOrg/kafka-connect-client/issues/76).
 - Add Constructors to various internal "DTO" classes, this allows for easier testing/mocking of responses. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 4.0.2 (10/09/2022)
+- Adds `KafkaConnectClient::restartConnector(final PostConnectorRestart connectorRestartRequest)` [Issue-78](https://github.com/SourceLabOrg/kafka-connect-client/issues/78).
 - Fix Javadoc on KafkaConnectClient::deleteConnector(). [issue-76](https://github.com/SourceLabOrg/kafka-connect-client/issues/76).
-- Add Constructors to various internal classes: 
-  - [ConnectServerVersion](https://github.com/SourceLabOrg/kafka-connect-client/blob/master/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectServerVersion.java#L23)
-  - [Task](https://github.com/SourceLabOrg/kafka-connect-client/blob/master/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/Task.java#L25)
+- Add Constructors to various internal "DTO" classes, this allows for easier testing/mocking of responses. 
 - com.fasterxml.jackson.core from 2.13.3 -> 2.13.4
 - 
 ## 4.0.1 (08/20/2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.0.2 (10/09/2022)
+- Fix Javadoc on KafkaConnectClient::deleteConnector(). [issue-76](https://github.com/SourceLabOrg/kafka-connect-client/issues/76).
+- Add Constructors to various internal classes: 
+  - [ConnectServerVersion](https://github.com/SourceLabOrg/kafka-connect-client/blob/master/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectServerVersion.java#L23)
+  - [Task](https://github.com/SourceLabOrg/kafka-connect-client/blob/master/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/Task.java#L25)
+
 ## 4.0.1 (08/20/2022)
 #### Internal Dependency Updates
 - com.fasterxml.jackson.core from 2.13.0 -> 2.13.3

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-connect-client</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2</version>
     <packaging>jar</packaging>
 
     <!-- Require Maven 3.3.9 -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <http-components.version>4.5.13</http-components.version>
 
         <!-- Jackson version -->
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.13.4</jackson.version>
 
         <!-- Define which version of junit you'll be running -->
         <junit.version>4.13.2</junit.version>

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/KafkaConnectClient.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/KafkaConnectClient.java
@@ -284,8 +284,8 @@ public class KafkaConnectClient {
     }
 
     /**
-     * Resume a connector.
-     * https://docs.confluent.io/current/connect/references/restapi.html#put--connectors-(string-name)-resume
+     * Delete a connector.
+     * https://docs.confluent.io/platform/current/connect/references/restapi.html#delete--connectors-(string-name)-
      *
      * @param connectorName Name of connector to resume.
      * @return Boolean true if success.

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/KafkaConnectClient.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/KafkaConnectClient.java
@@ -258,7 +258,19 @@ public class KafkaConnectClient {
      * @return Boolean true if success.
      */
     public Boolean restartConnector(final String connectorName) {
-        return submitRequest(new PostConnectorRestart(connectorName));
+        return restartConnector(new PostConnectorRestart(connectorName));
+    }
+
+    /**
+     * Restart a connector.
+     * https://docs.confluent.io/current/connect/references/restapi.html#post--connectors-(string-name)-restart
+     *
+     * @param connectorRestartRequest Defines the connector restart request.
+     * @return Boolean true if success.
+     */
+    public Boolean restartConnector(final PostConnectorRestart connectorRestartRequest)
+    {
+        return submitRequest(connectorRestartRequest);
     }
 
     /**

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectServerVersion.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectServerVersion.java
@@ -26,7 +26,7 @@ public class ConnectServerVersion {
     private String kafkaClusterId;
 
     /**
-     * Constructor.
+     * Default Constructor.
      */
     public ConnectServerVersion()
     {

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectServerVersion.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectServerVersion.java
@@ -26,6 +26,22 @@ public class ConnectServerVersion {
     private String kafkaClusterId;
 
     /**
+     * Constructor.
+     */
+    public ConnectServerVersion()
+    {
+    }
+
+    /**
+     * Constructor.
+     */
+    public ConnectServerVersion(final String version, final String commit, final String kafkaClusterId) {
+        this.version = version;
+        this.commit = commit;
+        this.kafkaClusterId = kafkaClusterId;
+    }
+
+    /**
      * Version of running Kafka-Connect server.
      * @return Version of running Kafka-Connect server.
      */

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorDefinition.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorDefinition.java
@@ -17,6 +17,8 @@
 
 package org.sourcelab.kafka.connect.apiclient.request.dto;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +30,23 @@ public final class ConnectorDefinition {
     private String type;
     private Map<String, String> config;
     private List<TaskDefinition> tasks;
+
+    /**
+     * Default constructor.
+     */
+    public ConnectorDefinition()
+    {
+    }
+
+    /**
+     * Constructor.
+     */
+    public ConnectorDefinition(final String name, final String type, final Map<String, String> config, final List<TaskDefinition> tasks) {
+        this.name = name;
+        this.type = type;
+        this.config = new HashMap<>(config);
+        this.tasks = new ArrayList<>(tasks);
+    }
 
     public String getName() {
         return name;
@@ -61,6 +80,20 @@ public final class ConnectorDefinition {
     public static final class TaskDefinition {
         private String connector;
         private int task;
+
+        /**
+         * Default Constructor.
+         */
+        public TaskDefinition() {
+        }
+
+        /**
+         * Constructor.
+         */
+        public TaskDefinition(final String connector, final int task) {
+            this.connector = connector;
+            this.task = task;
+        }
 
         public String getConnector() {
             return connector;

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorPlugin.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorPlugin.java
@@ -28,6 +28,21 @@ public final class ConnectorPlugin {
     private String type;
     private String version;
 
+    /**
+     * Default constructor.
+     */
+    public ConnectorPlugin() {
+    }
+
+    /**
+     * Constructor.
+     */
+    public ConnectorPlugin(final String className, final String type, final String version) {
+        this.className = className;
+        this.type = type;
+        this.version = version;
+    }
+
     public String getClassName() {
         return className;
     }
@@ -44,6 +59,8 @@ public final class ConnectorPlugin {
     public String toString() {
         return "ConnectorPlugin{"
             + "className='" + className + '\''
+            + ", type='" + type + '\''
+            + ", version='" + version + '\''
             + '}';
     }
 }

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorPluginConfigDefinition.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorPluginConfigDefinition.java
@@ -29,6 +29,14 @@ public final class ConnectorPluginConfigDefinition {
     private final Map<String, String> config;
 
     /**
+     * Create new Builder instance for ConnectorPluginConfigDefinition.
+     * @return Builder instance for ConnectorPluginConfigDefinition.
+     */
+    public static ConnectorPluginConfigDefinition.Builder newBuilder() {
+        return new ConnectorPluginConfigDefinition.Builder();
+    }
+
+    /**
      * Constructor.
      * @param connectorPluginName Name of Connector Plugin.
      * @param config Configuration values for connector.
@@ -44,10 +52,6 @@ public final class ConnectorPluginConfigDefinition {
 
     public Map<String, String> getConfig() {
         return config;
-    }
-
-    public static ConnectorPluginConfigDefinition.Builder newBuilder() {
-        return new ConnectorPluginConfigDefinition.Builder();
     }
 
     @Override

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorPluginConfigValidationResults.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorPluginConfigValidationResults.java
@@ -29,6 +29,27 @@ public final class ConnectorPluginConfigValidationResults {
     private Collection<String> groups = new ArrayList<>();
     private Collection<Config> configs = new ArrayList<>();
 
+    /**
+     * Default constructor.
+     */
+    public ConnectorPluginConfigValidationResults() {
+    }
+
+    /**
+     * Constructor.
+     */
+    public ConnectorPluginConfigValidationResults(
+        final String name,
+        final int errorCount,
+        final Collection<String> groups,
+        final Collection<Config> configs
+    ) {
+        this.name = name;
+        this.errorCount = errorCount;
+        this.groups = new ArrayList<>(groups);
+        this.configs = new ArrayList<>(configs);
+    }
+
     public String getName() {
         return name;
     }
@@ -62,6 +83,20 @@ public final class ConnectorPluginConfigValidationResults {
         private Definition definition;
         private Value value;
 
+        /**
+         * Default constructor.
+         */
+        public Config() {
+        }
+
+        /**
+         * Constructor.
+         */
+        public Config(final Definition definition, final Value value) {
+            this.definition = definition;
+            this.value = value;
+        }
+
         public Definition getDefinition() {
             return definition;
         }
@@ -93,6 +128,41 @@ public final class ConnectorPluginConfigValidationResults {
             private String displayName;
             private Collection<String> dependents = new ArrayList<>();
             private int order;
+
+            /**
+             * Default constructor.
+             */
+            public Definition() {
+            }
+
+            /**
+             * Constructor.
+             */
+            public Definition(
+                final String name,
+                final String type,
+                final boolean required,
+                final String defaultValue,
+                final String importance,
+                final String documentation,
+                final String group,
+                final String width,
+                final String displayName,
+                final Collection<String> dependents,
+                final int order
+            ) {
+                this.name = name;
+                this.type = type;
+                this.required = required;
+                this.defaultValue = defaultValue;
+                this.importance = importance;
+                this.documentation = documentation;
+                this.group = group;
+                this.width = width;
+                this.displayName = displayName;
+                this.dependents = new ArrayList<>(dependents);
+                this.order = order;
+            }
 
             public String getName() {
                 return name;
@@ -165,6 +235,29 @@ public final class ConnectorPluginConfigValidationResults {
             private Collection<String> recommendedValues = new ArrayList<>();
             private Collection<String> errors = new ArrayList<>();
             private boolean visible = true;
+
+            /**
+             * Default constructor.
+             */
+            public Value() {
+            }
+
+            /**
+             * Constructor.
+             */
+            public Value(
+                final String name,
+                final String value,
+                final Collection<String> recommendedValues,
+                final Collection<String> errors,
+                final boolean visible
+            ) {
+                this.name = name;
+                this.value = value;
+                this.recommendedValues = new ArrayList<>(recommendedValues);
+                this.errors = new ArrayList<>(errors);
+                this.visible = visible;
+            }
 
             public String getName() {
                 return name;

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorStatus.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorStatus.java
@@ -17,7 +17,9 @@
 
 package org.sourcelab.kafka.connect.apiclient.request.dto;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +31,22 @@ public class ConnectorStatus {
     private String type;
     private Map<String, String> connector;
     private List<TaskStatus> tasks;
+
+    /**
+     * Default constructor.
+     */
+    public ConnectorStatus() {
+    }
+
+    /**
+     * Constructor.
+     */
+    public ConnectorStatus(final String name, final String type, final Map<String, String> connector, final List<TaskStatus> tasks) {
+        this.name = name;
+        this.type = type;
+        this.connector = new HashMap<>(connector);
+        this.tasks = new ArrayList<>(tasks);
+    }
 
     public String getName() {
         return name;
@@ -64,6 +82,22 @@ public class ConnectorStatus {
         private String state;
         private String workerId;
         private String trace;
+
+        /**
+         * Default constructor.
+         */
+        public TaskStatus() {
+        }
+
+        /**
+         * Constructor.
+         */
+        public TaskStatus(final int id, final String state, final String workerId, final String trace) {
+            this.id = id;
+            this.state = state;
+            this.workerId = workerId;
+            this.trace = trace;
+        }
 
         public int getId() {
             return id;

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorsWithExpandedMetadata.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/ConnectorsWithExpandedMetadata.java
@@ -29,13 +29,26 @@ import java.util.stream.Collectors;
 /**
  * Deployed Connectors extended with all available associated Metadata.
  *
- * Currently this includes both 'info' and 'status' metadata.
+ * Currently, this includes both 'info' and 'status' metadata.
  *
  * Requires Kafka-Connect server 2.3.0+
  */
 public class ConnectorsWithExpandedMetadata implements ConnectorsWithExpandedInfo, ConnectorsWithExpandedStatus {
     @JsonAnySetter
     private Map<String, ConnectorsWithExpandedMetadata.ConnectorWithExpandedMetadata> results = new HashMap<>();
+
+    /**
+     * Default Constructor.
+     */
+    public ConnectorsWithExpandedMetadata() {
+    }
+
+    /**
+     * Constructor.
+     */
+    public ConnectorsWithExpandedMetadata(final Map<String, ConnectorWithExpandedMetadata> results) {
+        this.results = new HashMap<>(results);
+    }
 
     @Override
     public Collection<String> getConnectorNames() {
@@ -113,6 +126,20 @@ public class ConnectorsWithExpandedMetadata implements ConnectorsWithExpandedInf
 
         @JsonProperty("status")
         private ConnectorStatus status;
+
+        /**
+         * Default constructor.
+         */
+        public ConnectorWithExpandedMetadata() {
+        }
+
+        /**
+         * Constructor.
+         */
+        public ConnectorWithExpandedMetadata(final ConnectorDefinition info, final ConnectorStatus status) {
+            this.info = info;
+            this.status = status;
+        }
 
         public ConnectorStatus getStatus() {
             return status;

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/NewConnectorDefinition.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/NewConnectorDefinition.java
@@ -29,6 +29,14 @@ public final class NewConnectorDefinition {
     private final Map<String, String> config;
 
     /**
+     * Create new Builder instance for NewConnectorDefinition.
+     * @return new Builder instance for NewConnectorDefinition.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
      * Constructor.
      * @param name Name of Connector.
      * @param config Configuration values for connector.
@@ -44,10 +52,6 @@ public final class NewConnectorDefinition {
 
     public Map<String, String> getConfig() {
         return config;
-    }
-
-    public static Builder newBuilder() {
-        return new Builder();
     }
 
     @Override

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/Task.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/Task.java
@@ -26,6 +26,16 @@ public final class Task {
     private TaskId id;
     private Map<String, String> config;
 
+    public Task() {
+
+    }
+
+    public Task(final TaskId id, Map<String, String> config)
+    {
+        this.id = id;
+        this.config = config;
+    }
+
     public TaskId getId() {
         return id;
     }
@@ -49,6 +59,16 @@ public final class Task {
         private String connector;
         private int task;
 
+        public TaskId()
+        {
+
+        }
+
+        public TaskId(final String connector, final int task) {
+            this.connector = connector;
+            this.task = task;
+        }
+
         public String getConnector() {
             return connector;
         }
@@ -65,4 +85,5 @@ public final class Task {
                 + '}';
         }
     }
+
 }

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/Task.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/Task.java
@@ -17,6 +17,7 @@
 
 package org.sourcelab.kafka.connect.apiclient.request.dto;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -26,14 +27,19 @@ public final class Task {
     private TaskId id;
     private Map<String, String> config;
 
+    /**
+     * Default constructor.
+     */
     public Task() {
-
     }
 
-    public Task(final TaskId id, Map<String, String> config)
+    /**
+     * Constructor.
+     */
+    public Task(final TaskId id, final Map<String, String> config)
     {
         this.id = id;
-        this.config = config;
+        this.config = new HashMap<>(config);
     }
 
     public TaskId getId() {
@@ -59,11 +65,16 @@ public final class Task {
         private String connector;
         private int task;
 
+        /**
+         * Default constructor.
+         */
         public TaskId()
         {
-
         }
 
+        /**
+         * Constructor.
+         */
         public TaskId(final String connector, final int task) {
             this.connector = connector;
             this.task = task;

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/TaskStatus.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/dto/TaskStatus.java
@@ -26,6 +26,22 @@ public final class TaskStatus {
     private String trace;
     private String workerId;
 
+    /**
+     * Default constructor.
+     */
+    public TaskStatus() {
+    }
+
+    /**
+     * Constructor.
+     */
+    public TaskStatus(final int id, final String state, final String trace, final String workerId) {
+        this.id = id;
+        this.state = state;
+        this.trace = trace;
+        this.workerId = workerId;
+    }
+
     public int getId() {
         return id;
     }

--- a/src/main/java/org/sourcelab/kafka/connect/apiclient/request/post/PostConnectorRestart.java
+++ b/src/main/java/org/sourcelab/kafka/connect/apiclient/request/post/PostConnectorRestart.java
@@ -30,8 +30,14 @@ import java.util.Objects;
  * Defines a request to restart a connector.
  */
 public final class PostConnectorRestart implements PostRequest<Boolean> {
+    /**
+     * Defines the name of the connector to restart.
+     */
     private final String connectorName;
 
+    /**
+     * Additional options to pass with the request.
+     */
     private Map<String, Boolean> options = new HashMap<>();
 
     /**


### PR DESCRIPTION
- Adds constructors to various "DTO" objects to allow for easier testing and mocking.
- Fix javadoc for #76 
- Adds `KafkaConnectClient::restartConnector(final PostConnectorRestart connectorRestartRequest)` method for #78 